### PR TITLE
rename id column

### DIFF
--- a/quiz_answer_table.py
+++ b/quiz_answer_table.py
@@ -11,7 +11,7 @@ class QuizAnswer(Model):
     time_attempted = DateTimeField()
     points_earned = FloatField(constraints=[Check('points_earned > 0')])
     time_of_finish = DateTimeField()
-    id = ForeignKeyField(QuizQuestion, to_field='id')
+    question_id = ForeignKeyField(QuizQuestion, to_field='id')   ## call this something else 
     user_answer = CharField()
     correct_or_not = BooleanField()
     question = CharField()

--- a/quiz_questions.py
+++ b/quiz_questions.py
@@ -120,8 +120,9 @@ def display_questions(num_of_questions, category_name):
         correct_answer = False
         end_of_question = datetime.datetime.now()
        
+        # check the value of points_earned_total
         user_results = QuizAnswer(time_attempted=start_of_question,points_earned=points_earned_total,
-        time_of_finish=end_of_question, id=id_of_question,user_answer=user_guess,correct_or_not=correct_answer, question=question_ask)
+        time_of_finish=end_of_question, question_id=id_of_question,user_answer=user_guess,correct_or_not=correct_answer, question=question_ask)
         user_results.save()
     end_time = datetime.datetime.now()
     time_taken = end_time - start


### PR DESCRIPTION
Peewee adds an id column to each table. So the id column named in the QuizAnswer model is being renamed id_id to avoid conflicts, you can see that in DB Browser.  The id isn't the ID of an answer, it's the id of a question from the question table, so rename it something like quiz_question_id.  

You may need to delete the quiz answer table using DB browser before running your code so peewee can create the new table with the new column name.

